### PR TITLE
Enable ssl redirect on production

### DIFF
--- a/src/main/kotlin/theagainagain/WebService.kt
+++ b/src/main/kotlin/theagainagain/WebService.kt
@@ -9,8 +9,8 @@ import mu.KotlinLogging
 import spark.Request
 import spark.Route
 import spark.Spark
-
 private val logger = KotlinLogging.logger {}
+
 
 class WebService @Inject constructor(private val webServiceInitializer: WebServiceInitializer): AbstractIdleService() {
     override fun startUp() {

--- a/src/main/kotlin/theagainagain/configuration/EnvironmentHelper.kt
+++ b/src/main/kotlin/theagainagain/configuration/EnvironmentHelper.kt
@@ -21,4 +21,13 @@ class EnvironmentHelper @Inject constructor(val env: EnvironmentProvider) {
             value.toLong()
         }
     }
+
+    fun get(key: String, default: Boolean): Boolean {
+        val value = env.get(key)
+        return if(StringUtils.isEmpty(value)) {
+            default
+        }else {
+            value.toBoolean()
+        }
+    }
 }

--- a/src/main/kotlin/theagainagain/configuration/ServiceConfiguration.kt
+++ b/src/main/kotlin/theagainagain/configuration/ServiceConfiguration.kt
@@ -3,7 +3,18 @@ package theagainagain.configuration
 import com.google.inject.Inject
 
 class ServiceConfiguration @Inject constructor(val env: EnvironmentHelper) {
+    companion object {
+        const val PORT: String = "PORT"
+        const val PORT_DEFAULT: Int = 5000
+        const val ENABLE_SSL_REDIRECT: String = "ENABLE_SSL_REDIRECT"
+        const val ENABLE_SSL_REDIRECT_DEFAULT: Boolean = false
+    }
+
     fun getPort(): Int {
-        return env.get("PORT", 5000)
+        return env.get(PORT, PORT_DEFAULT)
+    }
+
+    fun sslRedirectEnabled(): Boolean {
+        return env.get(ENABLE_SSL_REDIRECT, ENABLE_SSL_REDIRECT_DEFAULT)
     }
 }

--- a/src/test/groovy/theagainagain/ServiceConfigurationTest.groovy
+++ b/src/test/groovy/theagainagain/ServiceConfigurationTest.groovy
@@ -5,6 +5,8 @@ import theagainagain.configuration.EnvironmentHelper
 import theagainagain.configuration.EnvironmentProvider
 import theagainagain.configuration.ServiceConfiguration
 
+import static theagainagain.configuration.ServiceConfiguration.*
+
 class ServiceConfigurationTest extends Specification {
 
     EnvironmentHelper environmentHelper
@@ -16,25 +18,49 @@ class ServiceConfigurationTest extends Specification {
 
     def "test getPort returns default"() {
         given:
-        environmentProvider.get("PORT") >> ""
+        environmentProvider.get(PORT) >> ""
         def configuration = new ServiceConfiguration(environmentHelper)
 
         when:
         def port = configuration.getPort()
 
         then:
-        port == 5000
+        port == PORT_DEFAULT
     }
 
     def "test getPort returns non-default"() {
         given:
-        environmentProvider.get("PORT") >> "8080"
+        environmentProvider.get(PORT) >> "${PORT_DEFAULT + 1}"
         def configuration = new ServiceConfiguration(environmentHelper)
 
         when:
         def port = configuration.getPort()
 
         then:
-        port == 8080
+        port == PORT_DEFAULT + 1
+    }
+
+    def "test redirectToSsl returns default value"() {
+        given:
+        environmentProvider.get(ENABLE_SSL_REDIRECT) >> ""
+        def configuration = new ServiceConfiguration(environmentHelper)
+
+        when:
+        def enabled = configuration.sslRedirectEnabled()
+
+        then:
+        enabled == ENABLE_SSL_REDIRECT_DEFAULT
+    }
+
+    def "test redirectToSsl can be enabled"() {
+        given:
+        environmentProvider.get(ENABLE_SSL_REDIRECT) >> "true"
+        def configuration = new ServiceConfiguration(environmentHelper)
+
+        when:
+        def enabled = configuration.sslRedirectEnabled()
+
+        then:
+        enabled
     }
 }


### PR DESCRIPTION
This makes ssl redirect configurable. In the non-prod environments there
wont be real ssl, this forces the user to go to https when it is
enabled, which I have done in heroku