### PR TITLE
A little service cleanup and logging

### DIFF
--- a/src/main/kotlin/theagainagain/Main.kt
+++ b/src/main/kotlin/theagainagain/Main.kt
@@ -8,7 +8,9 @@ import com.google.inject.Inject
 import dev.misfitlabs.kotlinguice4.getInstance
 import mu.KotlinLogging
 import org.slf4j.bridge.SLF4JBridgeHandler
+import sun.misc.Signal
 import theagainagain.configuration.ServiceConfiguration
+import kotlin.system.exitProcess
 
 private val logger = KotlinLogging.logger {}
 
@@ -18,10 +20,20 @@ fun main(args: Array<String>) {
     val injector = Guice.createInjector(ServiceModule())
     val main = injector.getInstance<Main>()
     main.apply {
+        configuration.logConfig()
         logger.info("Starting Services")
         val serviceManager = ServiceManager(ImmutableList.of<Service>(this.webService))
+        signalHandler(serviceManager)
         serviceManager.startAsync()
         serviceManager.awaitStopped()
+        exitProcess(0)
+    }
+}
+
+fun signalHandler(serviceManager: ServiceManager) {
+    Signal.handle(Signal("INT")) {
+        logger.info("shutting down")
+        serviceManager.stopAsync()
     }
 }
 

--- a/src/main/kotlin/theagainagain/ServiceModule.kt
+++ b/src/main/kotlin/theagainagain/ServiceModule.kt
@@ -1,7 +1,25 @@
 package theagainagain
 
+import com.google.inject.Provider
+import com.google.inject.name.Names
 import dev.misfitlabs.kotlinguice4.KotlinModule
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import theagainagain.configuration.ServiceConfiguration
 
 class ServiceModule : KotlinModule() {
+    companion object {
+        const val SERVICE_CONFIG_LOGGER: String = "ServiceConfigurationLogger"
+    }
 
+    override fun configure() {
+        super.configure()
+        bind<Logger>().annotatedWith(Names.named(SERVICE_CONFIG_LOGGER)).toProvider<ServiceConfigurationLoggerProvider>()
+    }
+}
+
+class ServiceConfigurationLoggerProvider: Provider<Logger> {
+    override fun get(): Logger {
+        return LoggerFactory.getLogger(ServiceConfiguration.javaClass)
+    }
 }

--- a/src/main/kotlin/theagainagain/WebService.kt
+++ b/src/main/kotlin/theagainagain/WebService.kt
@@ -9,10 +9,10 @@ import mu.KotlinLogging
 import spark.Request
 import spark.Route
 import spark.Spark
+
 private val logger = KotlinLogging.logger {}
 
-
-class WebService @Inject constructor(private val webServiceInitializer: WebServiceInitializer): AbstractIdleService() {
+class WebService @Inject constructor(private val webServiceInitializer: WebServiceInitializer) : AbstractIdleService() {
     override fun startUp() {
         logger.info("web service starting")
         webServiceInitializer.initialize(setUpEndpoints)
@@ -26,6 +26,11 @@ class WebService @Inject constructor(private val webServiceInitializer: WebServi
     val setUpEndpoints = Runnable {
         logger.info("setting up endpoints")
         Spark.get("/", MediaType.JSON_UTF_8.toString(), root)
+        Spark.get("/webhook/github", MediaType.JSON_UTF_8.toString(), githubWebHook)
+    }
+
+    private val githubWebHook = Route { request: Request, _ ->
+        logger.info("handling webhook github.")
     }
 
     private val root = Route { request: Request, _ ->

--- a/src/main/kotlin/theagainagain/configuration/EnvironmentHelper.kt
+++ b/src/main/kotlin/theagainagain/configuration/EnvironmentHelper.kt
@@ -30,4 +30,17 @@ class EnvironmentHelper @Inject constructor(val env: EnvironmentProvider) {
             value.toBoolean()
         }
     }
+
+    fun getKeys(): String {
+        val stringBuilder: StringBuilder = StringBuilder("[")
+        env.getKeys().forEach{
+            stringBuilder
+                    .append(it)
+                    .append(",")
+        }
+        return stringBuilder
+                .deleteCharAt(stringBuilder.lastIndex)
+                .append("]")
+                .toString()
+    }
 }

--- a/src/main/kotlin/theagainagain/configuration/EnvironmentProvider.kt
+++ b/src/main/kotlin/theagainagain/configuration/EnvironmentProvider.kt
@@ -7,4 +7,8 @@ class EnvironmentProvider {
     fun get(key: String): String {
         return  System.getenv(key) ?: ""
     }
+
+    fun getKeys(): List<String> {
+        return System.getenv().keys.toMutableList()
+    }
 }

--- a/src/main/kotlin/theagainagain/configuration/ServiceConfiguration.kt
+++ b/src/main/kotlin/theagainagain/configuration/ServiceConfiguration.kt
@@ -1,8 +1,11 @@
 package theagainagain.configuration
 
 import com.google.inject.Inject
+import com.google.inject.name.Named
+import org.slf4j.Logger
+import theagainagain.ServiceModule.Companion.SERVICE_CONFIG_LOGGER
 
-class ServiceConfiguration @Inject constructor(val env: EnvironmentHelper) {
+class ServiceConfiguration @Inject constructor(private val env: EnvironmentHelper, @Named(SERVICE_CONFIG_LOGGER) val logger: Logger) {
     companion object {
         const val PORT: String = "PORT"
         const val PORT_DEFAULT: Int = 5000
@@ -16,5 +19,9 @@ class ServiceConfiguration @Inject constructor(val env: EnvironmentHelper) {
 
     fun sslRedirectEnabled(): Boolean {
         return env.get(ENABLE_SSL_REDIRECT, ENABLE_SSL_REDIRECT_DEFAULT)
+    }
+
+    fun logConfig() {
+        logger.info("ENVIRONMENT KEYS: ${env.getKeys().replace("\n", "").replace("\r", "")}")
     }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
This commit adds signal handling so that when dev mode stops it returns
a valid return code rather than null. That was kinda bugging me. I added
a logback.xml so that I'm not getting spammed with debug logging when I
only really care about info level logging.

Also this is now logging the environment variables being passed in. This
will give me a cheat sheet for when I try to figure out what heroku is
sending my service.

I added a test for the new logging, which allowed me to explore
how to do named bindings in kotlin.

Finally, I added a logger for the github webhook endpoint I'm planning
on developing.