### PR TITLE
cleanup logging and response

### DIFF
--- a/src/main/kotlin/theagainagain/WebService.kt
+++ b/src/main/kotlin/theagainagain/WebService.kt
@@ -31,6 +31,7 @@ class WebService @Inject constructor(private val webServiceInitializer: WebServi
 
     private val githubWebHook = Route { request: Request, _ ->
         logger.info("handling webhook github.")
+        "OK"
     }
 
     private val root = Route { request: Request, _ ->

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
The logback was logging the timestamp and thread. The timestamp was redundant because heroku is providing that, and I don't see much value in knowing which thread it is on at this point. 

Also the webhook was returning the string for Unit, which is bad, I'm explicitly returning OK now.