### PR TITLE
Fix ui location logic

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,5 @@
 {
   "name": "The Again Again",
   "description": "A homepage.",
+  "stack": "container"
 }

--- a/app.json
+++ b/app.json
@@ -1,5 +1,4 @@
 {
   "name": "The Again Again",
   "description": "A homepage.",
-  "image": "heroku/gradle"
 }

--- a/src/main/kotlin/theagainagain/configuration/ServiceConfiguration.kt
+++ b/src/main/kotlin/theagainagain/configuration/ServiceConfiguration.kt
@@ -17,7 +17,7 @@ class ServiceConfiguration
         const val PORT_DEFAULT: Int = 8080
         const val ENABLE_SSL_REDIRECT: String = "ENABLE_SSL_REDIRECT"
         const val ENABLE_SSL_REDIRECT_DEFAULT: Boolean = false
-        const val AWS_ACCESS_KEY_ID: String = "AWS_ACCESS_KEY_ID"
+        const val PROD_UI: String = "PROD_UI"
         const val PROD_UI_LOCATION: String = "/ui"
         const val LOCALLY_BUILT_UI_LOCATION: String = "/ui/build"
         const val USER_DIR: String = "user.dir"
@@ -40,7 +40,7 @@ class ServiceConfiguration
     }
 
     fun shouldFetchUi(): Boolean {
-        return env.getKeys().contains(AWS_ACCESS_KEY_ID)
+        return env.getKeys().contains(PROD_UI)
     }
 
     fun getUiLocation(): String {

--- a/src/test/groovy/theagainagain/ServiceConfigurationTest.groovy
+++ b/src/test/groovy/theagainagain/ServiceConfigurationTest.groovy
@@ -94,7 +94,7 @@ class ServiceConfigurationTest extends Specification {
 
     def "test should fetch UI when aws set"() {
         given:
-        environmentProvider.keys >> [AWS_ACCESS_KEY_ID]
+        environmentProvider.keys >> [PROD_UI]
         def configuration = new ServiceConfiguration(environmentHelper, mockLogger, "123")
 
         when:
@@ -119,7 +119,7 @@ class ServiceConfigurationTest extends Specification {
     def "test get ui location when should fetch UI"() {
         given:
         environmentProvider.getProperty(USER_DIR) >> ""
-        environmentProvider.keys >> [AWS_ACCESS_KEY_ID]
+        environmentProvider.keys >> [PROD_UI]
         def configuration = new ServiceConfiguration(environmentHelper, mockLogger, "123")
 
         when:


### PR DESCRIPTION
By default it should be getting the UI from the locally built UI, and
then I'm overriding it in the review apps and prod deployment.