### PR TITLE
Fix dependabot build

### DIFF
--- a/.github/workflows/ui-builder.yml
+++ b/.github/workflows/ui-builder.yml
@@ -23,7 +23,7 @@ jobs:
       run: echo "##[set-output name=name;]$(echo theagainagain-${GITHUB_SHA}.tar.gz)"
       id: archive_name
     - name: branch name
-      run: echo "##[set-output name=name;]$(echo ${GITHUB_REF#refs/heads/})"
+      run: echo "##[set-output name=name;]$(echo ${GITHUB_REF#refs/heads/})" | sed 's/\//_/g'
       id: branch_name
     - name: tar ui
       run: mkdir build && tar -czvf build/${{steps.archive_name.outputs.name}} ui/build


### PR DESCRIPTION
The build was failing because of how dependabot name's it's branches.