### PR TITLE
Add service version back to the api

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -34,6 +34,7 @@ jobs:
       AWS_REGION: 'us-west-2'
       TF_VAR_ZONE_ID: ${{ secrets.ZONE_ID }}
       TF_VAR_DOMAIN_NAME: ${{ secrets.TF_VAR_DOMAIN_NAME }}
+      TF_VAR_TAG: ${{ inputs.tag }}
     defaults:
       run:
         working-directory: terraform

--- a/api-lambda/src/main/kotlin/info/offthecob/lambda/DataFetcherIndex.kt
+++ b/api-lambda/src/main/kotlin/info/offthecob/lambda/DataFetcherIndex.kt
@@ -1,11 +1,18 @@
 package info.offthecob.lambda
 
 import graphql.schema.DataFetcher
+import javax.inject.Inject
+import javax.inject.Named
 
-class DataFetcherIndex {
+class DataFetcherIndex @Inject constructor(@Named("serviceVersion") private val serviceVersion: String) {
     fun thing() = DataFetcher {
         listOf(Thing("thing1"), Thing("thing2"))
+    }
+
+    fun serviceDefinition() = DataFetcher {
+        ServiceDefinition(serviceVersion)
     }
 }
 
 data class Thing(val name: String)
+data class ServiceDefinition(var version: String)

--- a/api-lambda/src/main/kotlin/info/offthecob/lambda/ServiceModule.kt
+++ b/api-lambda/src/main/kotlin/info/offthecob/lambda/ServiceModule.kt
@@ -13,6 +13,17 @@ import javax.inject.Singleton
 
 class ServiceModule : KotlinModule() {
 
+    companion object {
+        const val DEFAULT_SERVICE_VERSION = "r9999"
+    }
+
+    @Provides
+    @Singleton
+    @Named("serviceVersion")
+    fun serviceVersion(): String {
+        return System.getenv("SERVICE_VERSION") ?: DEFAULT_SERVICE_VERSION
+    }
+
     @Provides
     @Singleton
     @Named("schema")
@@ -47,6 +58,7 @@ class ServiceModule : KotlinModule() {
     fun runtimeWiring(dataFetcherIndex: DataFetcherIndex): RuntimeWiring {
         return RuntimeWiring.newRuntimeWiring().type("Query") { builder ->
             builder.dataFetcher("things", dataFetcherIndex.thing())
+            builder.dataFetcher("serviceDefinition", dataFetcherIndex.serviceDefinition())
         }.build()
     }
 }

--- a/api-lambda/src/main/resources/schema.graphql
+++ b/api-lambda/src/main/resources/schema.graphql
@@ -2,8 +2,13 @@ type Thing {
     name: String
 }
 
+type ServiceDefinition {
+    version: String!
+}
+
 type Query {
     things: [Thing]
+    serviceDefinition: ServiceDefinition
 }
 
 schema {

--- a/api-lambda/src/test/groovy/info/offthecob/lambda/GraphqlServiceTest.groovy
+++ b/api-lambda/src/test/groovy/info/offthecob/lambda/GraphqlServiceTest.groovy
@@ -44,4 +44,18 @@ class GraphqlServiceTest extends Specification {
         response.contains("thing1")
         response.contains("thing2")
     }
+
+    def "default service version"() {
+        given:
+        def graphql = Guice.createInjector(new ServiceModule()).getInstance(GraphqlService.class)
+        def query = new GraphqlRequest("{ serviceDefinition { version } }", [:], "")
+        def json = JsonOutput.toJson(query)
+        def request = TestUtils.buildRequest("POST", json)
+
+        when:
+        def response = graphql.request(json, request)
+
+        then:
+        response.contains(ServiceModule.DEFAULT_SERVICE_VERSION)
+    }
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -13,4 +13,8 @@ module "api" {
       source_arn = "${module.api_gateway.apigatewayv2_api_execution_arn}/*/*"
     }
   }
+
+  environment_variables = {
+    SERVICE_VERSION = var.TAG
+  }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,2 +1,3 @@
 variable "API_IMAGE" {}
 variable "ZONE_ID" {}
+variable "TAG" {}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,7 +8,7 @@ import Home from './Home'
 import ApolloClient from 'apollo-boost'
 
 const client = new ApolloClient({
-  uri: '/graphql',
+  uri: 'https://api-staging.offthecob.info/graphql',
   request: operation => {
     operation.setContext({
       headers: {

--- a/ui/src/Home.tsx
+++ b/ui/src/Home.tsx
@@ -39,7 +39,7 @@ const Home: React.FC = () => {
   return (
     <div className="App">
       <header className="App-header">
-        <span>bro</span>
+        <span>Hello</span>
       </header>
       <footer>
         <span> <Version /> <Link to="/graphiql">Graphiql</Link></span>


### PR DESCRIPTION
This was in the code originally when I did this work for heroku, so now
that things are working in aws, it's time to add this stuff back.